### PR TITLE
Add deps for JVM Clojure compatibility

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src"]
  :deps  {org.babashka/http-client {:mvn/version "0.4.19"}
          cheshire/cheshire        {:mvn/version "5.13.0"}
-         org.babashka/cli         {:mvn/version "0.8.59"}}}
+         org.babashka/cli         {:mvn/version "0.8.59"}
+         babashka/fs              {:mvn/version "0.5.20"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,4 +2,5 @@
  :deps  {org.babashka/http-client {:mvn/version "0.4.19"}
          cheshire/cheshire        {:mvn/version "5.13.0"}
          org.babashka/cli         {:mvn/version "0.8.59"}
-         babashka/fs              {:mvn/version "0.5.20"}}}
+         babashka/fs              {:mvn/version "0.5.20"}
+         babashka/process         {:mvn/version "0.5.22"}}}


### PR DESCRIPTION
I tried running your code from a JVM REPL. That crashed, because two missing dependencies, `babashka/fs` and `babashka/process`.

I assume that you wanted JVM Clojure compatibility (since you created a `deps.edn` file)?

If you don't care about JVM compatibility, just close this PR. In that case, you could also delete `deps.edn` and reduce `bb.edn` to `{}`.